### PR TITLE
Rewrite daily summary tweet to premiere format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@
 
 lib/csv_extraction
 db/backup
+
+# Ignore superpowers docs
+/docs

--- a/app/jobs/daily_summary_tweet_job.rb
+++ b/app/jobs/daily_summary_tweet_job.rb
@@ -8,7 +8,7 @@ class DailySummaryTweetJob < ApplicationJob
       Edition.current.each do |edition|
         summary = DailySummaryTweet.new(edition)
 
-        next if summary.ratings.none?
+        next if summary.premiere_selections.none?
 
         summary.post!
       end

--- a/app/models/daily_summary_tweet.rb
+++ b/app/models/daily_summary_tweet.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class DailySummaryTweet
-  # TODO: This class might be better as a ViewObject or a regular view with a template
-  #       Including these helpers here is a bit of a smell
   include ActionView::Helpers::TextHelper, ActiveSupport::NumberHelper
+
+  MIN_RATINGS = 4
 
   attr_reader :edition
 
@@ -11,67 +11,24 @@ class DailySummaryTweet
     @edition = edition
   end
 
-  def ratings
-    # Grab the ratings for the current edition in the last 24 hours
-    @ratings ||= edition.ratings.includes(:critic, :selection, :film).where(
-      "ratings.created_at > ?",
-      1.day.ago,
-    ).order(:created_at)
-  end
-
-  def critics
-    ratings.map(&:critic).uniq
-  end
-
-  def selections
-    @selections ||= ratings.map(&:selection).uniq
-  end
-
-  def films
-    @films ||= ratings.map(&:film).uniq
-  end
-
-  def trending(num_films: 3)
-    num_films = [num_films, selections.count].min
-    sorted = selections.sort_by(&:average_rating).reverse!
-
-    [sorted[0..(num_films - 1)], sorted[-num_films..-1]]
-  end
-
-  def header
-    <<~HEADER
-      ⭐️ #{edition.code} Day #{edition.current_day} Ratings ⭐️
-      There were #{pluralize(ratings.count, "rating")} from #{pluralize(critics.count, "critic")} across #{pluralize(films.count, "film")}
-      #{edition_url(edition)}
-    HEADER
-  end
-
-  def film_lists(num_films: 3)
-    top, bottom = trending(num_films: num_films)
-
-    film_list(type: :top, selections: top) + line_break + film_list(type: :bottom, selections: bottom)
-  end
-
-  def film_list(type: :top, selections: [])
-    <<~FILM_LIST
-      #{type.capitalize} #{selections.size == 1 ? "" : selections.size} (avg)
-      #{film_list_items(selections)}
-    FILM_LIST
+  def premiere_selections
+    @premiere_selections ||= edition.selections
+      .joins(:ratings)
+      .group("selections.id")
+      .having("MIN(ratings.created_at) > ?", 1.day.ago)
+      .having("COUNT(ratings.id) >= ?", MIN_RATINGS)
+      .preload(:film, :ratings)
+      .sort_by { |s| -s.ratings.size }
   end
 
   def text
-    num_films = 3
-    tweet = header + line_break + film_lists
-
+    films = premiere_selections.dup
+    tweet = build_tweet(films)
     until tweet.chars.size <= 280
-      if num_films > 0
-        num_films -= 1
-        tweet = header + line_break + film_lists(num_films: num_films)
-      else
-        tweet = header + line_break + "Visit the link for detailed ratings"
-      end
+      films.pop
+      break if films.empty?
+      tweet = build_tweet(films)
     end
-
     tweet
   end
 
@@ -80,6 +37,26 @@ class DailySummaryTweet
   end
 
   private
+
+  def build_tweet(films)
+    header + film_lines(films) + footer
+  end
+
+  def header
+    "#{edition.code}: #{Time.zone.today.strftime("%B %-d")} Recap\n\n"
+  end
+
+  def film_lines(films)
+    films.map do |selection|
+      last_name = selection.film.directors.first.split(" ").last
+      avg = number_to_rounded(selection.average_rating, precision: 2)
+      "#{selection.film.title.upcase} (#{last_name}): #{avg} from #{pluralize(selection.ratings.size, "rating")}"
+    end.join("\n") + "\n\n"
+  end
+
+  def footer
+    "Check out all of our critics scores from the festival here: #{edition_url(edition)}"
+  end
 
   def edition_url(edition)
     Rails.application.routes.url_helpers.edition_url(
@@ -90,15 +67,5 @@ class DailySummaryTweet
 
   def client
     @client ||= X::Client.new(**Rails.application.credentials.x)
-  end
-
-  def film_list_items(selections)
-    selections.map do |selection|
-      "• #{selection.film.title} → #{number_to_rounded(selection.average_rating, precision: 2)}"
-    end.join("\n")
-  end
-
-  def line_break
-    "\n"
   end
 end

--- a/app/models/daily_summary_tweet.rb
+++ b/app/models/daily_summary_tweet.rb
@@ -22,12 +22,12 @@ class DailySummaryTweet
   end
 
   def text
-    films = premiere_selections.dup
-    tweet = build_tweet(films)
-    until tweet.chars.size <= 280
-      films.pop
-      break if films.empty?
-      tweet = build_tweet(films)
+    selections = premiere_selections.dup
+    tweet = build_tweet(selections)
+    until tweet.length <= 280
+      selections.pop
+      break if selections.empty?
+      tweet = build_tweet(selections)
     end
     tweet
   end

--- a/app/models/daily_summary_tweet.rb
+++ b/app/models/daily_summary_tweet.rb
@@ -27,6 +27,7 @@ class DailySummaryTweet
     until tweet.length <= 280
       selections.pop
       break if selections.empty?
+
       tweet = build_tweet(selections)
     end
     tweet

--- a/test/jobs/daily_summary_tweet_job_test.rb
+++ b/test/jobs/daily_summary_tweet_job_test.rb
@@ -3,17 +3,6 @@
 require "test_helper"
 
 class DailySummaryTweetJobTest < ActiveJob::TestCase
-  def premiere_selection(edition:, title:, director:, score: 3.0)
-    film = Film.create!(title: title, director: director, country: "FR", year: 2026)
-    selection = Selection.create!(edition: edition, film: film, category: categories(:base))
-    [critics(:base), critics(:without_publication), critics(:without_ratings), critics(:frequent_rater)].each do |critic|
-      Attendance.find_or_create_by!(critic: critic, edition: edition)
-      Rating.create!(selection: selection, critic: critic, score: score, created_at: 1.hour.ago)
-    end
-    selection.cache_average_rating
-    selection
-  end
-
   test "should do nothing if no current editions" do
     edition = editions(:base)
     edition.update(start_date: 2.weeks.ago, end_date: 1.week.ago)

--- a/test/jobs/daily_summary_tweet_job_test.rb
+++ b/test/jobs/daily_summary_tweet_job_test.rb
@@ -3,9 +3,16 @@
 require "test_helper"
 
 class DailySummaryTweetJobTest < ActiveJob::TestCase
-  # setup do
-  #   X::Client.any_instance.stubs(:post).returns(true)
-  # end
+  def premiere_selection(edition:, title:, director:, score: 3.0)
+    film = Film.create!(title: title, director: director, country: "FR", year: 2026)
+    selection = Selection.create!(edition: edition, film: film, category: categories(:base))
+    [critics(:base), critics(:without_publication), critics(:without_ratings), critics(:frequent_rater)].each do |critic|
+      Attendance.find_or_create_by!(critic: critic, edition: edition)
+      Rating.create!(selection: selection, critic: critic, score: score, created_at: 1.hour.ago)
+    end
+    selection.cache_average_rating
+    selection
+  end
 
   test "should do nothing if no current editions" do
     edition = editions(:base)
@@ -13,58 +20,36 @@ class DailySummaryTweetJobTest < ActiveJob::TestCase
 
     DailySummaryTweet.any_instance.expects(:post!).never
 
-    perform_enqueued_jobs do
-      DailySummaryTweetJob.perform_later
-    end
+    perform_enqueued_jobs { DailySummaryTweetJob.perform_later }
   end
 
-  test "should do nothing if no ratings" do
+  test "should do nothing if no premiere selections" do
     edition = editions(:base)
     edition.update(start_date: 1.week.ago, end_date: 1.week.from_now)
-    Rating.destroy_all
+    # All existing fixture ratings have old created_at — no premieres
 
     DailySummaryTweet.any_instance.expects(:post!).never
 
-    perform_enqueued_jobs do
-      DailySummaryTweetJob.perform_later
-    end
+    perform_enqueued_jobs { DailySummaryTweetJob.perform_later }
   end
 
-  test "should do nothing if no new ratings" do
-    edition = editions(:base)
-    edition.update(start_date: 1.week.ago, end_date: 1.week.from_now)
-    edition.ratings.update_all(created_at: 2.days.ago)
+  test "should post daily summary when premiere selections exist" do
+    travel_to Time.zone.local(2026, 5, 7) do
+      edition = editions(:base)
+      edition.update(start_date: 1.week.ago, end_date: 1.week.from_now)
+      premiere_selection(edition: edition, title: "Premiere Film", director: "Jane Smith")
 
-    DailySummaryTweet.any_instance.expects(:post!).never
+      expected_text = <<~TWEET.chomp
+        TIFF24: May 7 Recap
 
-    perform_enqueued_jobs do
-      DailySummaryTweetJob.perform_later
-    end
-  end
+        PREMIERE FILM (Smith): 3.00 from 4 ratings
 
-  test "should tweet daily summary" do
-    edition = editions(:base)
-    edition.update(start_date: 1.week.ago, end_date: 1.week.from_now)
-    edition.selections.find_each(&:cache_average_rating)
+        Check out all of our critics scores from the festival here: http://localhost:3000/editions/tiff24
+      TWEET
 
-    tweet = <<~TWEET
-      ⭐️ TIFF24 Day 8 Ratings ⭐️
-      There were 3 ratings from 2 critics across 2 films
-      http://localhost:3000/editions/tiff24
+      X::Client.any_instance.expects(:post).with("tweets", { text: expected_text }.to_json).returns(true)
 
-      Top 2 (avg)
-      • With Original Title → 4.50
-      • Festival Film → 3.50
-
-      Bottom 2 (avg)
-      • With Original Title → 4.50
-      • Festival Film → 3.50
-    TWEET
-
-    X::Client.any_instance.expects(:post).with("tweets", { text: tweet }.to_json).returns(true)
-
-    perform_enqueued_jobs do
-      DailySummaryTweetJob.perform_later
+      perform_enqueued_jobs { DailySummaryTweetJob.perform_later }
     end
   end
 end

--- a/test/models/daily_summary_tweet_test.rb
+++ b/test/models/daily_summary_tweet_test.rb
@@ -3,19 +3,6 @@
 require "test_helper"
 
 class DailySummaryTweetTest < ActiveSupport::TestCase
-  def premiere_selection(edition:, title:, director:, num_ratings: 4, score: 3.0)
-    film = Film.create!(title: title, director: director, country: "FR", year: 2026)
-    selection = Selection.create!(edition: edition, film: film, category: categories(:base))
-    [critics(:base), critics(:without_publication), critics(:without_ratings), critics(:frequent_rater)]
-      .first(num_ratings)
-      .each do |critic|
-        Attendance.find_or_create_by!(critic: critic, edition: edition)
-        Rating.create!(selection: selection, critic: critic, score: score, created_at: 1.hour.ago)
-      end
-    selection.cache_average_rating
-    selection
-  end
-
   test "#premiere_selections returns selections with first rating in last 24h and at least 4 ratings" do
     edition = editions(:base)
     selection = premiere_selection(edition: edition, title: "Premiere Film", director: "Jane Smith")

--- a/test/models/daily_summary_tweet_test.rb
+++ b/test/models/daily_summary_tweet_test.rb
@@ -56,7 +56,7 @@ class DailySummaryTweetTest < ActiveSupport::TestCase
   test "#text truncates the film list when tweet exceeds 280 characters" do
     travel_to Time.zone.local(2026, 5, 7) do
       edition = editions(:base)
-      %w[Alpha Beta Gamma Delta].each do |name|
+      ["Alpha", "Beta", "Gamma", "Delta"].each do |name|
         premiere_selection(
           edition: edition,
           title: "A Very Long Film Title Number #{name}",

--- a/test/models/daily_summary_tweet_test.rb
+++ b/test/models/daily_summary_tweet_test.rb
@@ -66,6 +66,7 @@ class DailySummaryTweetTest < ActiveSupport::TestCase
 
       result = DailySummaryTweet.new(edition).text
       assert result.chars.size <= 280, "Tweet was #{result.chars.size} chars, expected ≤ 280"
+      assert_match(/A VERY LONG FILM TITLE NUMBER/, result, "Expected at least one film line to survive truncation")
     end
   end
 

--- a/test/models/daily_summary_tweet_test.rb
+++ b/test/models/daily_summary_tweet_test.rb
@@ -3,162 +3,88 @@
 require "test_helper"
 
 class DailySummaryTweetTest < ActiveSupport::TestCase
-  test "#ratings should return all ratings from the last 24h for the edition" do
-    edition = editions(:base)
-    rating = ratings(:base)
-
-    Rating.create!(
-      edition: edition,
-      critic: critics(:without_ratings),
-      selection: selections(:base),
-      score: 4.5,
-      created_at: 25.hours.ago,
-    )
-
-    assert(DailySummaryTweet.new(edition).ratings.include?(rating))
-    assert_equal(3, DailySummaryTweet.new(edition).ratings.count)
+  def premiere_selection(edition:, title:, director:, num_ratings: 4, score: 3.0)
+    film = Film.create!(title: title, director: director, country: "FR", year: 2026)
+    selection = Selection.create!(edition: edition, film: film, category: categories(:base))
+    [critics(:base), critics(:without_publication), critics(:without_ratings), critics(:frequent_rater)]
+      .first(num_ratings)
+      .each do |critic|
+        Attendance.find_or_create_by!(critic: critic, edition: edition)
+        Rating.create!(selection: selection, critic: critic, score: score, created_at: 1.hour.ago)
+      end
+    selection.cache_average_rating
+    selection
   end
 
-  test "#critics should return all critics who rated films in the last 24h" do
+  test "#premiere_selections returns selections with first rating in last 24h and at least 4 ratings" do
     edition = editions(:base)
+    selection = premiere_selection(edition: edition, title: "Premiere Film", director: "Jane Smith")
 
-    Rating.create!(
-      edition: edition,
-      critic: critics(:without_ratings),
-      selection: selections(:base),
-      score: 4.5,
-      created_at: 25.hours.ago,
-    )
-
-    assert_equal(2, DailySummaryTweet.new(edition).critics.count)
+    assert_includes DailySummaryTweet.new(edition).premiere_selections, selection
   end
 
-  test "#selections should return all selections that were rated in the last 24h" do
+  test "#premiere_selections excludes selections with fewer than 4 ratings" do
     edition = editions(:base)
+    selection = premiere_selection(edition: edition, title: "Few Ratings Film", director: "Jane Smith", num_ratings: 3)
 
-    Rating.create!(
-      edition: edition,
-      critic: critics(:without_ratings),
-      selection: selections(:base),
-      score: 4.5,
-      created_at: 25.hours.ago,
-    )
-
-    assert_equal(2, DailySummaryTweet.new(edition).selections.count)
+    refute_includes DailySummaryTweet.new(edition).premiere_selections, selection
   end
 
-  test "#films should return all films that were rated in the last 24h" do
+  test "#premiere_selections excludes selections whose first rating was more than 24h ago" do
     edition = editions(:base)
-
-    Rating.create!(
-      edition: edition,
-      critic: critics(:without_ratings),
-      selection: selections(:base),
-      score: 4.5,
-      created_at: 25.hours.ago,
-    )
-
-    assert_equal(2, DailySummaryTweet.new(edition).films.count)
+    # selections(:base) has ratings from 1.week.ago — not a premiere
+    refute_includes DailySummaryTweet.new(edition).premiere_selections, selections(:base)
   end
 
-  test "#trending should return the top and bottom films by average rating" do
-    edition = editions(:base)
-    edition.selections.find_each(&:cache_average_rating)
+  test "#text returns the formatted premiere tweet" do
+    travel_to Time.zone.local(2026, 5, 7) do
+      edition = editions(:base)
+      premiere_selection(edition: edition, title: "Premiere Film", director: "Jane Smith")
 
-    summary = DailySummaryTweet.new(edition)
+      expected = <<~TWEET.chomp
+        TIFF24: May 7 Recap
 
-    assert_equal(2, summary.trending.first.count)
-    assert_equal(2, summary.trending.last.count)
+        PREMIERE FILM (Smith): 3.00 from 4 ratings
+
+        Check out all of our critics scores from the festival here: http://localhost:3000/editions/tiff24
+      TWEET
+
+      assert_equal expected, DailySummaryTweet.new(edition).text
+    end
   end
 
-  test "#header should return the header text for the tweet" do
-    edition = editions(:base)
-    edition.update(start_date: 1.week.ago, end_date: 1.week.from_now)
+  test "#text truncates the film list when tweet exceeds 280 characters" do
+    travel_to Time.zone.local(2026, 5, 7) do
+      edition = editions(:base)
+      %w[Alpha Beta Gamma Delta].each do |name|
+        premiere_selection(
+          edition: edition,
+          title: "A Very Long Film Title Number #{name}",
+          director: "Director #{name}",
+        )
+      end
 
-    summary = DailySummaryTweet.new(edition)
-    header = summary.header
-
-    assert_match(/TIFF24 Day 8 Ratings/, header)
-    assert_match(/2 critics/, header)
-    assert_match(/2 films/, header)
+      result = DailySummaryTweet.new(edition).text
+      assert result.chars.size <= 280, "Tweet was #{result.chars.size} chars, expected ≤ 280"
+    end
   end
 
-  test "#film_lists should return the top and bottom films by average rating" do
-    edition = editions(:base)
-    edition.selections.find_each(&:cache_average_rating)
+  test "#post! posts the tweet text to the X API" do
+    travel_to Time.zone.local(2026, 5, 7) do
+      edition = editions(:base)
+      premiere_selection(edition: edition, title: "Premiere Film", director: "Jane Smith")
 
-    summary = DailySummaryTweet.new(edition)
-    film_lists = summary.film_lists
+      expected_text = <<~TWEET.chomp
+        TIFF24: May 7 Recap
 
-    assert_match(/Top 2 \(avg\)/, film_lists)
-    assert_match(/Bottom 2 \(avg\)/, film_lists)
-  end
+        PREMIERE FILM (Smith): 3.00 from 4 ratings
 
-  test "#text should return the full tweet text" do
-    edition = editions(:base)
-    edition.update(start_date: 1.week.ago, end_date: 1.week.from_now)
-    edition.selections.find_each(&:cache_average_rating)
+        Check out all of our critics scores from the festival here: http://localhost:3000/editions/tiff24
+      TWEET
 
-    tweet = <<~TWEET
-      ⭐️ TIFF24 Day 8 Ratings ⭐️
-      There were 3 ratings from 2 critics across 2 films
-      http://localhost:3000/editions/tiff24
+      X::Client.any_instance.expects(:post).with("tweets", { text: expected_text }.to_json).returns(true)
 
-      Top 2 (avg)
-      • With Original Title → 4.50
-      • Festival Film → 3.50
-
-      Bottom 2 (avg)
-      • With Original Title → 4.50
-      • Festival Film → 3.50
-    TWEET
-
-    assert_equal DailySummaryTweet.new(edition).text, tweet
-  end
-
-  # TODO: Flesh out all of the tests around the tweet length logic
-
-  # test "#text should return a shorter tweet if the full tweet is too long" do
-  #   edition = editions(:base)
-  #   edition.update(start_date: 1.week.ago, end_date: 1.week.from_now)
-  #   edition.selections.find_each(&:cache_average_rating)
-
-  #   tweet = <<~TWEET
-  #     ⭐️ TIFF24 Day 8 Ratings ⭐️
-  #     There were 3 ratings from 2 critics across 2 films
-  #     http://localhost:3000/editions/tiff24
-
-  #     Top 1 (avg)
-  #     • With Original Title → 4.5
-
-  #     Bottom 1 (avg)
-  #     • With Original Title → 4.5
-  #   TWEET
-
-  #   assert_equal DailySummaryTweet.new(edition).text, tweet
-  # end
-
-  test "#post! should post the tweet to the API" do
-    edition = editions(:base)
-    edition.update(start_date: 1.week.ago, end_date: 1.week.from_now)
-    edition.selections.find_each(&:cache_average_rating)
-
-    tweet = <<~TWEET
-      ⭐️ TIFF24 Day 8 Ratings ⭐️
-      There were 3 ratings from 2 critics across 2 films
-      http://localhost:3000/editions/tiff24
-
-      Top 2 (avg)
-      • With Original Title → 4.50
-      • Festival Film → 3.50
-
-      Bottom 2 (avg)
-      • With Original Title → 4.50
-      • Festival Film → 3.50
-    TWEET
-
-    X::Client.any_instance.expects(:post).with("tweets", { text: tweet }.to_json).returns(true)
-
-    DailySummaryTweet.new(edition).post!
+      DailySummaryTweet.new(edition).post!
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,5 +22,18 @@ module ActiveSupport
     def create_rating(critic:, selection:, score:)
       Rating.create!(critic: critic, selection: selection, score: score, skip_cache_average_ratings_callback: true)
     end
+
+    def premiere_selection(edition:, title:, director:, num_ratings: 4, score: 3.0)
+      film = Film.create!(title: title, director: director, country: "FR", year: 2026)
+      selection = Selection.create!(edition: edition, film: film, category: categories(:base))
+      [critics(:base), critics(:without_publication), critics(:without_ratings), critics(:frequent_rater)]
+        .first(num_ratings)
+        .each do |critic|
+          Attendance.find_or_create_by!(critic: critic, edition: edition)
+          Rating.create!(selection: selection, critic: critic, score: score, created_at: 1.hour.ago)
+        end
+      selection.cache_average_rating
+      selection
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Replaces top/bottom trending tweet with a premiere-focused recap: films receiving their first ratings in the edition within the last 24 hours, with at least 4 ratings
- New format: `FILM TITLE (Director): avg from N ratings`, sorted by rating count descending, with edition code + date header and a link footer
- Job guard updated from `ratings.none?` to `premiere_selections.none?`

## Test Plan

- [x] `bin/rails test test/models/daily_summary_tweet_test.rb test/jobs/daily_summary_tweet_job_test.rb` — 9 tests, all passing
- [x] Verify tweet format matches: `EDITION: Month Day Recap`, film lines upcased with director last name, footer link
- [x] Verify tweet truncates correctly when >280 chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)