### PR TITLE
Add timezone support to festivals for local-time daily summary tweets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ db/backup
 
 # Ignore superpowers docs
 /docs
+
+# Ignore claude local settings and worktrees
+/.claude/worktrees
+/.claude/settings.local.json

--- a/app/controllers/admin/festivals_controller.rb
+++ b/app/controllers/admin/festivals_controller.rb
@@ -51,7 +51,7 @@ class Admin
     private
 
     def festival_params
-      params.require(:festival).permit(:name, :short_name, :url, :country)
+      params.require(:festival).permit(:name, :short_name, :url, :country, :timezone)
     end
   end
 end

--- a/app/jobs/daily_summary_tweet_job.rb
+++ b/app/jobs/daily_summary_tweet_job.rb
@@ -4,14 +4,14 @@ class DailySummaryTweetJob < ApplicationJob
   queue_as :default
 
   def perform(*args)
-    if Edition.current.any?
-      Edition.current.each do |edition|
-        summary = DailySummaryTweet.new(edition)
+    Edition.current.each do |edition|
+      local_time = Time.now.in_time_zone(edition.timezone)
+      next unless local_time.hour == 23 && local_time.min >= 45
 
-        next if summary.premiere_selections.none?
+      summary = DailySummaryTweet.new(edition)
+      next if summary.premiere_selections.none?
 
-        summary.post!
-      end
+      summary.post!
     end
   end
 end

--- a/app/models/daily_summary_tweet.rb
+++ b/app/models/daily_summary_tweet.rb
@@ -25,6 +25,8 @@ class DailySummaryTweet
   end
 
   def text
+    return "" if premiere_selections.none?
+
     selections = premiere_selections.dup
     tweet = build_tweet(selections)
     until tweet.length <= 280

--- a/app/models/daily_summary_tweet.rb
+++ b/app/models/daily_summary_tweet.rb
@@ -12,13 +12,16 @@ class DailySummaryTweet
   end
 
   def premiere_selections
-    @premiere_selections ||= edition.selections
-      .joins(:ratings)
-      .group("selections.id")
-      .having("MIN(ratings.created_at) > ?", 1.day.ago)
-      .having("COUNT(ratings.id) >= ?", MIN_RATINGS)
-      .preload(:film, :ratings)
-      .sort_by { |s| -s.ratings.size }
+    @premiere_selections ||= begin
+      local_midnight = Time.now.in_time_zone(edition.timezone).beginning_of_day
+      edition.selections
+        .joins(:ratings)
+        .group("selections.id")
+        .having("MIN(ratings.created_at) > ?", local_midnight)
+        .having("COUNT(ratings.id) >= ?", MIN_RATINGS)
+        .preload(:film, :ratings)
+        .sort_by { |s| -s.ratings.size }
+    end
   end
 
   def text
@@ -39,16 +42,17 @@ class DailySummaryTweet
 
   private
 
-  def build_tweet(films)
-    header + film_lines(films) + footer
+  def build_tweet(selections)
+    header + film_lines(selections) + footer
   end
 
   def header
-    "#{edition.code}: #{Time.zone.today.strftime("%B %-d")} Recap\n\n"
+    local_date = Time.now.in_time_zone(edition.timezone).to_date
+    "#{edition.code}: #{local_date.strftime("%B %-d")} Recap\n\n"
   end
 
-  def film_lines(films)
-    films.map do |selection|
+  def film_lines(selections)
+    selections.map do |selection|
       last_name = selection.film.directors.first.split(" ").last
       avg = number_to_rounded(selection.average_rating, precision: 2)
       "#{selection.film.title.upcase} (#{last_name}): #{avg} from #{pluralize(selection.ratings.size, "rating")}"

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -20,7 +20,7 @@ class Edition < ApplicationRecord
   validates :year, numericality: { only_integer: true, greater_than: 2023 }
   validates :end_date, comparison: { greater_than: :start_date }
 
-  delegate :name, :short_name, :country, to: :festival
+  delegate :name, :short_name, :country, :timezone, to: :festival
 
   def summary_critics_count
     critics.count

--- a/app/models/festival.rb
+++ b/app/models/festival.rb
@@ -9,4 +9,5 @@ class Festival < ApplicationRecord
   validates :name, :short_name, :url, :country, presence: true
   validates :url, format: { with: URI::DEFAULT_PARSER.make_regexp, message: "is not a valid URL" }
   validates :country, inclusion: { in: ISO3166::Country.all.map(&:alpha2) }
+  validates :timezone, inclusion: { in: ActiveSupport::TimeZone.all.map(&:name) }
 end

--- a/app/views/admin/festivals/_form.html.erb
+++ b/app/views/admin/festivals/_form.html.erb
@@ -18,6 +18,12 @@
       <%= form.label :country, class: "block text-gray-700 text-sm font-bold mb-2" %>
       <%= form.select :country, countries_select, {}, class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-500 sm:text-sm sm:leading-6" %>
     </div>
+    <div class="mb-4">
+      <%= form.label :timezone, class: "block text-gray-700 text-sm font-bold mb-2" %>
+      <%= form.time_zone_select :timezone, ActiveSupport::TimeZone.all,
+          { default: "UTC" },
+          class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-500 sm:text-sm sm:leading-6" %>
+    </div>
     <div class="flex items-center justify-between mt-8">
       <%= form.submit class: "bg-indigo-500 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded-sm focus:outline-hidden focus:shadow-outline" %>
     </div>

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -12,4 +12,4 @@
 production:
   daily_summary_tweet:
     class: "DailySummaryTweetJob"
-    schedule: "every day at 11:50pm"
+    schedule: "*/15 * * * *"

--- a/db/migrate/20260511014723_add_timezone_to_festivals.rb
+++ b/db/migrate/20260511014723_add_timezone_to_festivals.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTimezoneToFestivals < ActiveRecord::Migration[8.0]
+  def change
+    add_column(:festivals, :timezone, :string, null: false, default: "UTC")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,242 +10,243 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_06_022714) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_11_014723) do
   create_table "action_text_rich_texts", force: :cascade do |t|
-    t.string("name", null: false)
-    t.text("body")
-    t.string("record_type", null: false)
-    t.bigint("record_id", null: false)
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.index(["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true)
+    t.string "name", null: false
+    t.text "body"
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
   end
 
   create_table "active_storage_attachments", force: :cascade do |t|
-    t.string("name", null: false)
-    t.string("record_type", null: false)
-    t.bigint("record_id", null: false)
-    t.bigint("blob_id", null: false)
-    t.datetime("created_at", null: false)
-    t.index(["blob_id"], name: "index_active_storage_attachments_on_blob_id")
-    t.index(["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true)
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
   create_table "active_storage_blobs", force: :cascade do |t|
-    t.string("key", null: false)
-    t.string("filename", null: false)
-    t.string("content_type")
-    t.text("metadata")
-    t.string("service_name", null: false)
-    t.bigint("byte_size", null: false)
-    t.string("checksum")
-    t.datetime("created_at", null: false)
-    t.index(["key"], name: "index_active_storage_blobs_on_key", unique: true)
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.bigint("blob_id", null: false)
-    t.string("variation_digest", null: false)
-    t.index(["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true)
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
   create_table "admins", force: :cascade do |t|
-    t.string("username")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
+    t.string "username"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "attendances", force: :cascade do |t|
-    t.integer("critic_id", null: false)
-    t.integer("edition_id", null: false)
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.string("publication")
-    t.index(["critic_id"], name: "index_attendances_on_critic_id")
-    t.index(["edition_id"], name: "index_attendances_on_edition_id")
+    t.integer "critic_id", null: false
+    t.integer "edition_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "publication"
+    t.index ["critic_id"], name: "index_attendances_on_critic_id"
+    t.index ["edition_id"], name: "index_attendances_on_edition_id"
   end
 
   create_table "categories", force: :cascade do |t|
-    t.integer("edition_id", null: false)
-    t.string("name")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.integer("position", null: false)
-    t.boolean("standalone", default: false, null: false)
-    t.index(["edition_id", "position"], name: "index_categories_on_edition_id_and_position", unique: true)
-    t.index(["edition_id"], name: "index_categories_on_edition_id")
+    t.integer "edition_id", null: false
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "position", null: false
+    t.boolean "standalone", default: false, null: false
+    t.index ["edition_id", "position"], name: "index_categories_on_edition_id_and_position", unique: true
+    t.index ["edition_id"], name: "index_categories_on_edition_id"
   end
 
   create_table "critics", force: :cascade do |t|
-    t.string("first_name")
-    t.string("last_name")
-    t.string("publication")
-    t.string("country")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.string("slug")
-    t.index(["slug"], name: "index_critics_on_slug", unique: true)
+    t.string "first_name"
+    t.string "last_name"
+    t.string "publication"
+    t.string "country"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "slug"
+    t.index ["slug"], name: "index_critics_on_slug", unique: true
   end
 
   create_table "editions", force: :cascade do |t|
-    t.integer("festival_id", null: false)
-    t.integer("year")
-    t.string("code")
-    t.string("url")
-    t.date("start_date")
-    t.date("end_date")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.string("slug")
-    t.index(["festival_id", "slug"], name: "index_editions_on_festival_id_and_slug", unique: true)
-    t.index(["festival_id"], name: "index_editions_on_festival_id")
+    t.integer "festival_id", null: false
+    t.integer "year"
+    t.string "code"
+    t.string "url"
+    t.date "start_date"
+    t.date "end_date"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "slug"
+    t.index ["festival_id", "slug"], name: "index_editions_on_festival_id_and_slug", unique: true
+    t.index ["festival_id"], name: "index_editions_on_festival_id"
   end
 
   create_table "episodes", force: :cascade do |t|
-    t.string("title")
-    t.text("description")
-    t.integer("podcast_id", null: false)
-    t.string("url")
-    t.text("embed")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.string("slug")
-    t.string("provider_id")
-    t.text("summary")
-    t.datetime("published_at")
-    t.integer("duration")
-    t.integer("edition_id")
-    t.index(["edition_id"], name: "index_episodes_on_edition_id")
-    t.index(["podcast_id"], name: "index_episodes_on_podcast_id")
-    t.index(["published_at"], name: "index_episodes_on_published_at")
-    t.index(["slug"], name: "index_episodes_on_slug", unique: true)
+    t.string "title"
+    t.text "description"
+    t.integer "podcast_id", null: false
+    t.string "url"
+    t.text "embed"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "slug"
+    t.string "provider_id"
+    t.text "summary"
+    t.datetime "published_at"
+    t.integer "duration"
+    t.integer "edition_id"
+    t.index ["edition_id"], name: "index_episodes_on_edition_id"
+    t.index ["podcast_id"], name: "index_episodes_on_podcast_id"
+    t.index ["published_at"], name: "index_episodes_on_published_at"
+    t.index ["slug"], name: "index_episodes_on_slug", unique: true
   end
 
   create_table "festivals", force: :cascade do |t|
-    t.string("name")
-    t.string("short_name")
-    t.string("url")
-    t.string("country")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.string("slug")
-    t.index(["slug"], name: "index_festivals_on_slug", unique: true)
+    t.string "name"
+    t.string "short_name"
+    t.string "url"
+    t.string "country"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "slug"
+    t.string "timezone", default: "UTC", null: false
+    t.index ["slug"], name: "index_festivals_on_slug", unique: true
   end
 
   create_table "films", force: :cascade do |t|
-    t.string("title")
-    t.string("original_title")
-    t.string("director")
-    t.string("country")
-    t.integer("year")
-    t.decimal("overall_average_rating")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.string("slug")
-    t.string("normalized_title", null: false)
-    t.boolean("rateable", default: true, null: false)
-    t.text("summary")
-    t.integer("tmdb_id")
-    t.date("release_date")
-    t.string("poster_path")
-    t.string("backdrop_path")
-    t.index(["slug"], name: "index_films_on_slug", unique: true)
+    t.string "title"
+    t.string "original_title"
+    t.string "director"
+    t.string "country"
+    t.integer "year"
+    t.decimal "overall_average_rating"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "slug"
+    t.string "normalized_title", null: false
+    t.boolean "rateable", default: true, null: false
+    t.text "summary"
+    t.integer "tmdb_id"
+    t.date "release_date"
+    t.string "poster_path"
+    t.string "backdrop_path"
+    t.index ["slug"], name: "index_films_on_slug", unique: true
   end
 
   create_table "podcasts", force: :cascade do |t|
-    t.string("title", null: false)
-    t.text("description")
-    t.integer("user_id", null: false)
-    t.string("url")
-    t.string("slug", null: false)
-    t.boolean("platform", default: false)
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.index(["slug"], name: "index_podcasts_on_slug", unique: true)
-    t.index(["user_id"], name: "index_podcasts_on_user_id")
+    t.string "title", null: false
+    t.text "description"
+    t.integer "user_id", null: false
+    t.string "url"
+    t.string "slug", null: false
+    t.boolean "platform", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["slug"], name: "index_podcasts_on_slug", unique: true
+    t.index ["user_id"], name: "index_podcasts_on_user_id"
   end
 
   create_table "ratings", force: :cascade do |t|
-    t.integer("critic_id", null: false)
-    t.integer("selection_id", null: false)
-    t.decimal("score", precision: 2, scale: 1)
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.string("review_url")
-    t.text("impression")
-    t.index(["critic_id"], name: "index_ratings_on_critic_id")
-    t.index(["selection_id"], name: "index_ratings_on_selection_id")
+    t.integer "critic_id", null: false
+    t.integer "selection_id", null: false
+    t.decimal "score", precision: 2, scale: 1
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "review_url"
+    t.text "impression"
+    t.index ["critic_id"], name: "index_ratings_on_critic_id"
+    t.index ["selection_id"], name: "index_ratings_on_selection_id"
   end
 
   create_table "selections", force: :cascade do |t|
-    t.integer("edition_id", null: false)
-    t.integer("film_id", null: false)
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.decimal("average_rating")
-    t.integer("category_id")
-    t.index(["category_id"], name: "index_selections_on_category_id")
-    t.index(["edition_id"], name: "index_selections_on_edition_id")
-    t.index(["film_id"], name: "index_selections_on_film_id")
+    t.integer "edition_id", null: false
+    t.integer "film_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.decimal "average_rating"
+    t.integer "category_id"
+    t.index ["category_id"], name: "index_selections_on_category_id"
+    t.index ["edition_id"], name: "index_selections_on_edition_id"
+    t.index ["film_id"], name: "index_selections_on_film_id"
   end
 
   create_table "sessions", force: :cascade do |t|
-    t.integer("user_id", null: false)
-    t.string("user_agent")
-    t.string("ip_address")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.index(["user_id"], name: "index_sessions_on_user_id")
+    t.integer "user_id", null: false
+    t.string "user_agent"
+    t.string "ip_address"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_sessions_on_user_id"
   end
 
   create_table "sign_in_tokens", force: :cascade do |t|
-    t.integer("user_id", null: false)
-    t.index(["user_id"], name: "index_sign_in_tokens_on_user_id")
+    t.integer "user_id", null: false
+    t.index ["user_id"], name: "index_sign_in_tokens_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
-    t.string("email", null: false)
-    t.string("password_digest", null: false)
-    t.boolean("verified", default: false, null: false)
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.string("userable_type", null: false)
-    t.integer("userable_id", null: false)
-    t.index(["email"], name: "index_users_on_email", unique: true)
-    t.index(["userable_type", "userable_id"], name: "index_users_on_userable")
+    t.string "email", null: false
+    t.string "password_digest", null: false
+    t.boolean "verified", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "userable_type", null: false
+    t.integer "userable_id", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["userable_type", "userable_id"], name: "index_users_on_userable"
   end
 
   create_table "year_in_review_top_selections", force: :cascade do |t|
-    t.integer("year_in_review_id", null: false)
-    t.integer("selection_id", null: false)
-    t.integer("position", null: false)
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.decimal("combined_average_rating")
-    t.integer("combined_ratings_count")
-    t.decimal("bayesian_score")
-    t.index(["selection_id"], name: "index_year_in_review_top_selections_on_selection_id")
-    t.index(["year_in_review_id", "position"], name: "idx_yir_top_selections_on_yir_and_position", unique: true)
-    t.index(["year_in_review_id", "selection_id"], name: "idx_yir_top_selections_on_yir_and_selection", unique: true)
-    t.index(["year_in_review_id"], name: "index_year_in_review_top_selections_on_year_in_review_id")
+    t.integer "year_in_review_id", null: false
+    t.integer "selection_id", null: false
+    t.integer "position", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.decimal "combined_average_rating"
+    t.integer "combined_ratings_count"
+    t.decimal "bayesian_score"
+    t.index ["selection_id"], name: "index_year_in_review_top_selections_on_selection_id"
+    t.index ["year_in_review_id", "position"], name: "idx_yir_top_selections_on_yir_and_position", unique: true
+    t.index ["year_in_review_id", "selection_id"], name: "idx_yir_top_selections_on_yir_and_selection", unique: true
+    t.index ["year_in_review_id"], name: "index_year_in_review_top_selections_on_year_in_review_id"
   end
 
   create_table "year_in_reviews", force: :cascade do |t|
-    t.integer("year", null: false)
-    t.integer("editions_count", default: 0, null: false)
-    t.integer("critics_count", default: 0, null: false)
-    t.integer("films_count", default: 0, null: false)
-    t.integer("ratings_count", default: 0, null: false)
-    t.integer("five_star_ratings_count", default: 0, null: false)
-    t.integer("zero_star_ratings_count", default: 0, null: false)
-    t.integer("bombe_moiree_selection_id")
-    t.integer("most_divisive_selection_id")
-    t.datetime("generated_at")
-    t.datetime("created_at", null: false)
-    t.datetime("updated_at", null: false)
-    t.index(["bombe_moiree_selection_id"], name: "index_year_in_reviews_on_bombe_moiree_selection_id")
-    t.index(["most_divisive_selection_id"], name: "index_year_in_reviews_on_most_divisive_selection_id")
-    t.index(["year"], name: "index_year_in_reviews_on_year", unique: true)
+    t.integer "year", null: false
+    t.integer "editions_count", default: 0, null: false
+    t.integer "critics_count", default: 0, null: false
+    t.integer "films_count", default: 0, null: false
+    t.integer "ratings_count", default: 0, null: false
+    t.integer "five_star_ratings_count", default: 0, null: false
+    t.integer "zero_star_ratings_count", default: 0, null: false
+    t.integer "bombe_moiree_selection_id"
+    t.integer "most_divisive_selection_id"
+    t.datetime "generated_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["bombe_moiree_selection_id"], name: "index_year_in_reviews_on_bombe_moiree_selection_id"
+    t.index ["most_divisive_selection_id"], name: "index_year_in_reviews_on_most_divisive_selection_id"
+    t.index ["year"], name: "index_year_in_reviews_on_year", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/test/fixtures/festivals.yml
+++ b/test/fixtures/festivals.yml
@@ -5,9 +5,11 @@ base:
   short_name: TIFF
   url: https://tiff.net
   country: CA
+  timezone: Eastern Time (US & Canada)
 
 with_no_films:
   name: Cannes Film Festival
   short_name: Cannes
   url: https://festival-cannes.com
   country: FR
+  timezone: Paris

--- a/test/jobs/daily_summary_tweet_job_test.rb
+++ b/test/jobs/daily_summary_tweet_job_test.rb
@@ -4,32 +4,73 @@ require "test_helper"
 
 class DailySummaryTweetJobTest < ActiveJob::TestCase
   test "should do nothing if no current editions" do
-    edition = editions(:base)
-    edition.update(start_date: 2.weeks.ago, end_date: 1.week.ago)
+    travel_to Time.zone.local(2026, 5, 10, 23, 50, 0) do
+      edition = editions(:base)
+      edition.update(start_date: 2.weeks.ago, end_date: 1.week.ago)
 
-    DailySummaryTweet.any_instance.expects(:post!).never
+      DailySummaryTweet.any_instance.expects(:post!).never
 
-    perform_enqueued_jobs { DailySummaryTweetJob.perform_later }
+      perform_enqueued_jobs { DailySummaryTweetJob.perform_later }
+    end
+  end
+
+  test "should skip edition when local time is outside the tweet window" do
+    travel_to Time.zone.local(2026, 5, 10, 22, 0, 0) do # 10pm UTC — before window
+      festivals(:base).update!(timezone: "UTC")
+      edition = editions(:base)
+      edition.update(start_date: 1.week.ago, end_date: 1.week.from_now)
+      premiere_selection(edition: edition, title: "Premiere Film", director: "Jane Smith")
+
+      DailySummaryTweet.any_instance.expects(:post!).never
+
+      perform_enqueued_jobs { DailySummaryTweetJob.perform_later }
+    end
   end
 
   test "should do nothing if no premiere selections" do
-    edition = editions(:base)
-    edition.update(start_date: 1.week.ago, end_date: 1.week.from_now)
-    # All existing fixture ratings have old created_at — no premieres
+    travel_to Time.zone.local(2026, 5, 10, 23, 50, 0) do # 11:50pm UTC — inside window
+      festivals(:base).update!(timezone: "UTC")
+      edition = editions(:base)
+      edition.update(start_date: 1.week.ago, end_date: 1.week.from_now)
+      # All existing fixture ratings have old created_at — none pass today's beginning_of_day cutoff
 
-    DailySummaryTweet.any_instance.expects(:post!).never
+      DailySummaryTweet.any_instance.expects(:post!).never
 
-    perform_enqueued_jobs { DailySummaryTweetJob.perform_later }
+      perform_enqueued_jobs { DailySummaryTweetJob.perform_later }
+    end
   end
 
-  test "should post daily summary when premiere selections exist" do
-    travel_to Time.zone.local(2026, 5, 7) do
+  test "should post daily summary when inside the window and premiere selections exist" do
+    travel_to Time.zone.local(2026, 5, 10, 23, 50, 0) do # 11:50pm UTC — inside window
+      festivals(:base).update!(timezone: "UTC")
       edition = editions(:base)
       edition.update(start_date: 1.week.ago, end_date: 1.week.from_now)
       premiere_selection(edition: edition, title: "Premiere Film", director: "Jane Smith")
 
       expected_text = <<~TWEET.chomp
-        TIFF24: May 7 Recap
+        TIFF24: May 10 Recap
+
+        PREMIERE FILM (Smith): 3.00 from 4 ratings
+
+        Check out all of our critics scores from the festival here: http://localhost:3000/editions/tiff24
+      TWEET
+
+      X::Client.any_instance.expects(:post).with("tweets", { text: expected_text }.to_json).returns(true)
+
+      perform_enqueued_jobs { DailySummaryTweetJob.perform_later }
+    end
+  end
+
+  test "should fire for a festival at its local 11:45pm even when UTC time differs" do
+    # Paris (UTC+2): 11:50pm Paris = 9:50pm UTC
+    travel_to Time.zone.local(2026, 5, 10, 21, 50, 0) do # 9:50pm UTC
+      festivals(:base).update!(timezone: "Paris")
+      edition = editions(:base)
+      edition.update(start_date: 1.week.ago, end_date: 1.week.from_now)
+      premiere_selection(edition: edition, title: "Premiere Film", director: "Jane Smith")
+
+      expected_text = <<~TWEET.chomp
+        TIFF24: May 10 Recap
 
         PREMIERE FILM (Smith): 3.00 from 4 ratings
 

--- a/test/models/daily_summary_tweet_test.rb
+++ b/test/models/daily_summary_tweet_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 class DailySummaryTweetTest < ActiveSupport::TestCase
-  test "#premiere_selections returns selections with first rating in last 24h and at least 4 ratings" do
+  test "#premiere_selections returns selections with first rating today in the festival timezone and at least 4 ratings" do
     edition = editions(:base)
     selection = premiere_selection(edition: edition, title: "Premiere Film", director: "Jane Smith")
 
@@ -17,19 +17,38 @@ class DailySummaryTweetTest < ActiveSupport::TestCase
     refute_includes DailySummaryTweet.new(edition).premiere_selections, selection
   end
 
-  test "#premiere_selections excludes selections whose first rating was more than 24h ago" do
+  test "#premiere_selections excludes selections whose first rating was before today in the festival timezone" do
     edition = editions(:base)
-    # selections(:base) has ratings from 1.week.ago — not a premiere
+    # selections(:base) has ratings from 1.week.ago — before today's midnight
     refute_includes DailySummaryTweet.new(edition).premiere_selections, selections(:base)
   end
 
+  test "#premiere_selections uses festival-local midnight as the window cutoff" do
+    # At 1am UTC, UTC-2 local time is 11pm the previous day.
+    # beginning_of_day in UTC-2 = 2am UTC (midnight UTC-2).
+    # A rating from 25 hours ago (before local midnight) should be excluded.
+    travel_to Time.zone.local(2026, 5, 10, 1, 0, 0) do
+      festivals(:base).update!(timezone: "Mid-Atlantic") # UTC-2
+      edition = editions(:base)
+
+      old_selection = premiere_selection(
+        edition: edition,
+        title: "Old Premiere",
+        director: "Jane Smith",
+        created_at: 25.hours.ago,
+      )
+
+      refute_includes DailySummaryTweet.new(edition).premiere_selections, old_selection
+    end
+  end
+
   test "#text returns the formatted premiere tweet" do
-    travel_to Time.zone.local(2026, 5, 7) do
+    travel_to Time.zone.local(2026, 5, 10, 23, 50, 0) do
       edition = editions(:base)
       premiere_selection(edition: edition, title: "Premiere Film", director: "Jane Smith")
 
       expected = <<~TWEET.chomp
-        TIFF24: May 7 Recap
+        TIFF24: May 10 Recap
 
         PREMIERE FILM (Smith): 3.00 from 4 ratings
 
@@ -40,8 +59,18 @@ class DailySummaryTweetTest < ActiveSupport::TestCase
     end
   end
 
+  test "#text header uses festival-local date, not server date" do
+    # At 1am UTC, a UTC-2 festival is still on May 9
+    travel_to Time.zone.local(2026, 5, 10, 1, 0, 0) do
+      festivals(:base).update!(timezone: "Mid-Atlantic") # UTC-2
+      edition = editions(:base)
+
+      assert_equal "TIFF24: May 9 Recap\n\n", DailySummaryTweet.new(edition).send(:header)
+    end
+  end
+
   test "#text truncates the film list when tweet exceeds 280 characters" do
-    travel_to Time.zone.local(2026, 5, 7) do
+    travel_to Time.zone.local(2026, 5, 10, 23, 50, 0) do
       edition = editions(:base)
       ["Alpha", "Beta", "Gamma", "Delta"].each do |name|
         premiere_selection(
@@ -52,18 +81,18 @@ class DailySummaryTweetTest < ActiveSupport::TestCase
       end
 
       result = DailySummaryTweet.new(edition).text
-      assert result.chars.size <= 280, "Tweet was #{result.chars.size} chars, expected ≤ 280"
+      assert result.length <= 280, "Tweet was #{result.length} chars, expected ≤ 280"
       assert_match(/A VERY LONG FILM TITLE NUMBER/, result, "Expected at least one film line to survive truncation")
     end
   end
 
   test "#post! posts the tweet text to the X API" do
-    travel_to Time.zone.local(2026, 5, 7) do
+    travel_to Time.zone.local(2026, 5, 10, 23, 50, 0) do
       edition = editions(:base)
       premiere_selection(edition: edition, title: "Premiere Film", director: "Jane Smith")
 
       expected_text = <<~TWEET.chomp
-        TIFF24: May 7 Recap
+        TIFF24: May 10 Recap
 
         PREMIERE FILM (Smith): 3.00 from 4 ratings
 

--- a/test/models/daily_summary_tweet_test.rb
+++ b/test/models/daily_summary_tweet_test.rb
@@ -4,10 +4,12 @@ require "test_helper"
 
 class DailySummaryTweetTest < ActiveSupport::TestCase
   test "#premiere_selections returns selections with first rating today in the festival timezone and at least 4 ratings" do
-    edition = editions(:base)
-    selection = premiere_selection(edition: edition, title: "Premiere Film", director: "Jane Smith")
+    travel_to Time.zone.local(2026, 5, 10, 23, 50, 0) do
+      edition = editions(:base)
+      selection = premiere_selection(edition: edition, title: "Premiere Film", director: "Jane Smith")
 
-    assert_includes DailySummaryTweet.new(edition).premiere_selections, selection
+      assert_includes DailySummaryTweet.new(edition).premiere_selections, selection
+    end
   end
 
   test "#premiere_selections excludes selections with fewer than 4 ratings" do

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -105,6 +105,11 @@ class EditionTest < ActiveSupport::TestCase
     assert edition.ratings.include?(rating)
   end
 
+  test "#timezone delegates to the festival's timezone" do
+    edition = editions(:base)
+    assert_equal edition.festival.timezone, edition.timezone
+  end
+
   test "includes Summarizable concern" do
     assert_includes(Edition.ancestors, Summarizable)
   end

--- a/test/models/festival_test.rb
+++ b/test/models/festival_test.rb
@@ -57,4 +57,22 @@ class FestivalTest < ActiveSupport::TestCase
 
     assert(festival.past_editions.include?(edition))
   end
+
+  test "timezone defaults to UTC for a new festival" do
+    festival = Festival.new(name: "Test", short_name: "TEST", url: "https://test.com", country: "CA")
+    assert_equal "UTC", festival.timezone
+  end
+
+  test "is invalid with an unrecognized timezone" do
+    festival = festivals(:base)
+    festival.timezone = "Narnia/Cair_Paravel"
+    assert_not festival.valid?
+    assert_match(/is not included/, festival.errors.full_messages.join)
+  end
+
+  test "is valid with a recognized ActiveSupport timezone name" do
+    festival = festivals(:base)
+    festival.timezone = "Paris"
+    assert festival.valid?
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,14 +23,14 @@ module ActiveSupport
       Rating.create!(critic: critic, selection: selection, score: score, skip_cache_average_ratings_callback: true)
     end
 
-    def premiere_selection(edition:, title:, director:, num_ratings: 4, score: 3.0)
+    def premiere_selection(edition:, title:, director:, num_ratings: 4, score: 3.0, created_at: 1.hour.ago)
       film = Film.create!(title: title, director: director, country: "FR", year: 2026)
       selection = Selection.create!(edition: edition, film: film, category: categories(:base))
       [critics(:base), critics(:without_publication), critics(:without_ratings), critics(:frequent_rater)]
         .first(num_ratings)
         .each do |critic|
           Attendance.find_or_create_by!(critic: critic, edition: edition)
-          Rating.create!(selection: selection, critic: critic, score: score, created_at: 1.hour.ago)
+          Rating.create!(selection: selection, critic: critic, score: score, created_at: created_at)
         end
       selection.cache_average_rating
       selection


### PR DESCRIPTION
## Summary

- Adds a `timezone` column to `festivals` (default `UTC`, validated against `ActiveSupport::TimeZone`) and delegates it to `Edition`
- Updates `DailySummaryTweet` to use festival-local midnight for the premiere detection window and festival-local date for the recap header
- Switches `DailySummaryTweetJob` from a single daily cron to `*/15 * * * *` with a per-edition local-time window check (11:45pm–midnight), so each festival tweets at its own local time
- Adds a `time_zone_select` to the festival admin form

## Test Plan

- [x] Run `bin/rails test` — 359 runs, 0 failures
- [x] Create or edit a festival in the admin UI and confirm the timezone select appears with the correct default
- [ ] Verify a festival set to a non-UTC timezone posts its daily summary at 11:45pm local time (check job logs or manually invoke `DailySummaryTweetJob.perform_now` with a current edition)

## Notes

- 3 pre-existing errors in `Admin::FilmsControllerTest` and `Admin::SelectionsControllerTest` (TMDB API network calls) are unrelated to this change
- Stale `# TODO: Add a time zone to the edition model...` comment in `edition.rb:60` is now resolved by delegation — can be cleaned up in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)